### PR TITLE
⚡ Bolt: guard expensive debug logging of response text

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Guarding expensive logging arguments]
+**Learning:** Accessing `requests.Response.text` triggers automatic decoding of the response content, which can be expensive for large payloads. In Python's `logging` module, arguments passed to logging methods are evaluated even if the message is not emitted due to the current log level.
+**Action:** Always wrap logging calls that access `response.text` or perform other expensive operations in an `if logger.isEnabledFor(LEVEL)` block.

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -13,7 +13,11 @@ class ValueNotFound(ValueistException):
 
 def _fetch_value(url: str, selector: str):
     response = requests.get(url, timeout=10)
-    logger.debug("Looking for %s in %s", selector, response.text)
+    if logger.isEnabledFor(logging.DEBUG):
+        # We only access response.text if we are in debug mode
+        # to avoid unnecessary decoding of the response content
+        # for large payloads.
+        logger.debug("Looking for %s in %s", selector, response.text)
     soup = BeautifulSoup(response.content, "lxml")
     elements=soup.css.select(selector)
     if len(elements)<1:


### PR DESCRIPTION
Guarded expensive `response.text` access in `logger.debug` with `if logger.isEnabledFor(logging.DEBUG)`. This prevents unnecessary decoding of large HTML responses when the application is running in non-debug mode (which is the default). Added a journal entry to `.jules/bolt.md` documenting this pattern.

---
*PR created automatically by Jules for task [12649853111846443352](https://jules.google.com/task/12649853111846443352) started by @agalazis*