### PR TITLE
Improve Parsing Robustness and CLI Argument Disambiguation

### DIFF
--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -1,0 +1,50 @@
+import subprocess
+import json
+import pytest
+import sys
+
+def test_cli_quantifier_disambiguation():
+    # Selector is 'ANY', no quantifier specified.
+    # Positions: url parser selector operator value
+    # http://example.com str ANY eq "val" -> 5 positional args
+    # The CLI should NOT detect 'ANY' as a quantifier because there are only 5 positional args.
+
+    cmd = [
+        sys.executable, "-m", "web_valueist",
+        "http://example.com", "str", "h1", "eq", "Example Domain", "--json"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env={"PYTHONPATH": "."})
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["args"]["quantifier"] == "ANY"
+    assert data["args"]["selector"] == "h1"
+
+def test_cli_with_actual_quantifier():
+    # Positions: url parser quantifier selector operator value -> 6 args
+    cmd = [
+        sys.executable, "-m", "web_valueist",
+        "http://example.com", "str", "EVERY", "h1", "eq", "Example Domain", "--json"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env={"PYTHONPATH": "."})
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["args"]["quantifier"] == "EVERY"
+    assert data["args"]["selector"] == "h1"
+
+def test_cli_selector_named_any():
+    # Positions: url parser selector operator value -> 5 args
+    # Selector is 'ANY'
+    cmd = [
+        sys.executable, "-m", "web_valueist",
+        "http://example.com", "str", "ANY", "eq", "Example Domain", "--json"
+    ]
+    # This might fail if the selector 'ANY' doesn't match anything,
+    # but we want to check how it's PARSED.
+    # Actually evaluate will be called with url=http://example.com, parser=str, selector=ANY, operator=eq, value=Example Domain
+    result = subprocess.run(cmd, capture_output=True, text=True, env={"PYTHONPATH": "."})
+    # If selector 'ANY' is not found, it raises ValueNotFound and exits with 1.
+    # But --json should still output something if it reached main?
+    # Wait, if it raises ValueNotFound in __main__, it catches and exits 1.
+    # Let's check stderr for "Error: Value not found" which means it parsed correctly.
+    assert "Error: Value not found" in result.stderr
+    # If it misparsed, it would probably complain about missing arguments or wrong operator.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,26 @@
+import sys
+from unittest.mock import patch
+from web_valueist.__main__ import _detect_optional_arguments
+
+def test_detect_optional_arguments_with_6_args():
+    test_args = ["web_valueist", "http://example.com", "int", "ANY", ".price", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is True
+
+def test_detect_optional_arguments_with_5_args_and_any_selector():
+    # If there are only 5 positional args, the 3rd one (index 2) is the selector.
+    # It should NOT be detected as a quantifier even if its value is "ANY".
+    test_args = ["web_valueist", "http://example.com", "int", "ANY", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is False
+
+def test_detect_optional_arguments_with_every_quantifier():
+    test_args = ["web_valueist", "http://example.com", "int", "EVERY", ".price", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is True

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -8,6 +8,8 @@ def test_clean_float_string():
     assert _clean_float_string("1,234.567") == "1234.567"
     assert _clean_float_string("1.234.567,89") == "1234567.89"
     assert _clean_float_string("1,234,567.89") == "1234567.89"
+    assert _clean_float_string("-10.50") == "-10.50"
+    assert _clean_float_string("-$ 10.50") == "-10.50"
 
 def test_parse_int():
     assert _parse_int("100") == 100

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -4,6 +4,10 @@ def test_clean_float_string():
     assert _clean_float_string("1,234.56") == "1234.56"
     assert _clean_float_string("1.234,56") == "1234.56"
     assert _clean_float_string("$ 10.50") == "10.50"
+    assert _clean_float_string("1.2345") == "1.2345"
+    assert _clean_float_string("1,234.567") == "1234.567"
+    assert _clean_float_string("1.234.567,89") == "1234567.89"
+    assert _clean_float_string("1,234,567.89") == "1234567.89"
 
 def test_parse_int():
     assert _parse_int("100") == 100
@@ -19,6 +23,13 @@ def test_parse_bool():
     assert _parse_bool("False") is False
     assert _parse_bool("1") is True
     assert _parse_bool("0") is False
+    assert _parse_bool("yes") is True
+    assert _parse_bool("no") is False
+    assert _parse_bool("Y") is True
+    assert _parse_bool("N") is False
+    assert _parse_bool("t") is True
+    assert _parse_bool("f") is False
+    assert _parse_bool("unknown") is False
 
 def test_parse_interface():
     assert parse("int", "10") == 10

--- a/web_valueist/__main__.py
+++ b/web_valueist/__main__.py
@@ -23,14 +23,30 @@ class CliArgs(Args):
 
 def _detect_optional_arguments(config: dict[str, dict]):
     import sys
+
     positional_args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
     results = {}
+    # We expect 5 positional arguments without quantifier, 6 with quantifier
+    # url, parser_name, [quantifier], selector, operator_name, value
+    has_quantifier = len(positional_args) == 6
+
     for name, attr in config.items():
-        pos = attr["position"]
-        possible_values = attr["possible_values"]
-        results[name] = (
-            len(positional_args) > pos and positional_args[pos].upper() in possible_values
-        )
+        if name == "quantifier":
+            pos = attr["position"]
+            possible_values = attr["possible_values"]
+            results[name] = (
+                has_quantifier
+                and len(positional_args) > pos
+                and positional_args[pos].upper() in possible_values
+            )
+        else:
+            # Fallback for other potential optional arguments
+            pos = attr["position"]
+            possible_values = attr["possible_values"]
+            results[name] = (
+                len(positional_args) > pos
+                and positional_args[pos].upper() in possible_values
+            )
     return results
 
 

--- a/web_valueist/lib/parser.py
+++ b/web_valueist/lib/parser.py
@@ -8,33 +8,75 @@ type Parser = Literal["int", "str", "bool", "float"]
 
 INT_EXPONENT=Decimal('0')
 
-def _clean_float_string(val:str):
-    """Cleans up float string and returns float
-    The cleanup regex does the following
-    1) Keeps only digits, commas and dots
-    2) Removes commas or dots that do not match coma or dot and the final 1 or 2 digits
-
+def _clean_float_string(val: str):
+    """Cleans up float string and returns float string ready for Decimal/float conversion.
+    It attempts to handle thousands separators (both . and ,) by assuming the last
+    separator is the decimal point if multiple separators or different types are present.
 
     Args:
         val (str): a string that is expected to be parsed as float
 
     Returns:
-        str: The float for the provided string 
-    """    
-    return re.sub(r"[^\d|\.|\,]|(?![.,]\d{1,2}$)[.,]", "", val).replace(',', '.')
+        str: The normalized float string
+    """
+    # Keep only digits, dots and commas
+    cleaned = re.sub(r"[^\d.,]", "", val)
 
-def _clean_bool_tiny_int_string(val: str):
-    """Cleans up bool/tiny int values and returns tiny int string
+    # Find all separators
+    separators = re.findall(r"[.,]", cleaned)
+    if not separators:
+        return cleaned
+
+    # If we have multiple separators or both types,
+    # the last one is the decimal point, others are thousands separators.
+    last_sep = separators[-1]
+    other_sep = "," if last_sep == "." else "."
+
+    # Remove all 'other' separators
+    cleaned = cleaned.replace(other_sep, "")
+
+    # Now we only have 'last_sep' type. If there are multiple, they are all thousands separators
+    # UNLESS it's the last one.
+    if cleaned.count(last_sep) > 1:
+        # 1.234.567 -> 1234567 (wait, if there's no decimal it's just an int)
+        # Actually, if there are multiple, we remove all of them.
+        cleaned = cleaned.replace(last_sep, "")
+    else:
+        # Only one separator left, treat as decimal point
+        cleaned = cleaned.replace(last_sep, ".")
+
+    return cleaned
+
+
+def _parse_bool(val: str):
+    """Parses a string into a boolean.
+    Supports true/false, yes/no, 1/0, t/f (case-insensitive).
 
     Args:
-        val str: a string that is expected to be parsed as bool/ tiny int
+        val (str): a string that is expected to be parsed as boolean
 
     Returns:
-        str: The tiny int for the provided string 
+        bool: The boolean for the provided string
     """
-    return re.sub('(?i)(?!true|false|1|0|t|f).', '',val).upper().replace('F','0').replace('T', '1')
+    normalized = val.strip().lower()
+    truthy = {"true", "1", "t", "yes", "y"}
+    falsy = {"false", "0", "f", "no", "n"}
 
-def _parse_int(val:str):
+    if normalized in truthy:
+        return True
+    if normalized in falsy:
+        return False
+
+    # Fallback/Error handling: if it's not recognized, we could return False or raise
+    # Let's be consistent with previous behavior but safer.
+    # Previous behavior was int(cleaned_string) which could raise.
+    try:
+        return bool(int(re.sub(r"\D", "", normalized)))
+    except (ValueError, TypeError):
+        return False
+
+
+def _parse_int(val: str):
     """ Cleans up int string and returns int
     The cleanup regex does the following
     1) Cleans up string as float
@@ -49,20 +91,9 @@ def _parse_int(val:str):
     float_string=_clean_float_string(val)
     return int(Decimal(float_string).quantize(exp=INT_EXPONENT, rounding=ROUND_HALF_UP))
 
-def _parse_float(val:str):
+def _parse_float(val: str):
     return float(_clean_float_string(val))
 
-def _parse_bool(val:str):
-    """Cleans up bool/tiny int string and returns bool
-
-    Args:
-        val (str): a string that is expected to be parsed as boolean
-
-    Returns:
-        bool: The boolean for the provided string
-    """    
-    tiny_int_string = _clean_bool_tiny_int_string(val)
-    return bool(int(tiny_int_string))
 
 _parsers = {
     "int": _parse_int, 

--- a/web_valueist/lib/parser.py
+++ b/web_valueist/lib/parser.py
@@ -12,6 +12,7 @@ def _clean_float_string(val: str):
     """Cleans up float string and returns float string ready for Decimal/float conversion.
     It attempts to handle thousands separators (both . and ,) by assuming the last
     separator is the decimal point if multiple separators or different types are present.
+    Also preserves leading negative sign.
 
     Args:
         val (str): a string that is expected to be parsed as float
@@ -19,11 +20,18 @@ def _clean_float_string(val: str):
     Returns:
         str: The normalized float string
     """
-    # Keep only digits, dots and commas
-    cleaned = re.sub(r"[^\d.,]", "", val)
+    # Keep only digits, dots, commas and leading minus
+    cleaned = re.sub(r"[^\d.,-]", "", val)
 
-    # Find all separators
-    separators = re.findall(r"[.,]", cleaned)
+    # Ensure minus is only at the beginning
+    is_negative = cleaned.startswith("-")
+    cleaned = cleaned.replace("-", "")
+    if is_negative:
+        cleaned = "-" + cleaned
+
+    # Find all separators (ignoring the negative sign)
+    to_check = cleaned[1:] if is_negative else cleaned
+    separators = re.findall(r"[.,]", to_check)
     if not separators:
         return cleaned
 
@@ -33,19 +41,18 @@ def _clean_float_string(val: str):
     other_sep = "," if last_sep == "." else "."
 
     # Remove all 'other' separators
-    cleaned = cleaned.replace(other_sep, "")
+    prefix = "-" if is_negative else ""
+    body = to_check.replace(other_sep, "")
 
-    # Now we only have 'last_sep' type. If there are multiple, they are all thousands separators
-    # UNLESS it's the last one.
-    if cleaned.count(last_sep) > 1:
-        # 1.234.567 -> 1234567 (wait, if there's no decimal it's just an int)
-        # Actually, if there are multiple, we remove all of them.
-        cleaned = cleaned.replace(last_sep, "")
+    # Now we only have 'last_sep' type in body.
+    if body.count(last_sep) > 1:
+        # Multiple instances of the same separator are treated as thousands separators
+        body = body.replace(last_sep, "")
     else:
         # Only one separator left, treat as decimal point
-        cleaned = cleaned.replace(last_sep, ".")
+        body = body.replace(last_sep, ".")
 
-    return cleaned
+    return prefix + body
 
 
 def _parse_bool(val: str):
@@ -68,8 +75,6 @@ def _parse_bool(val: str):
         return False
 
     # Fallback/Error handling: if it's not recognized, we could return False or raise
-    # Let's be consistent with previous behavior but safer.
-    # Previous behavior was int(cleaned_string) which could raise.
     try:
         return bool(int(re.sub(r"\D", "", normalized)))
     except (ValueError, TypeError):


### PR DESCRIPTION
This change addresses several bugs in the `web_valueist` tool:
1. **Float Parsing**: The previous regex-based cleaning was fragile and would remove decimal points from high-precision floats (e.g., `1.2345`). The new logic intelligently identifies decimal points and thousands separators.
2. **Boolean Parsing**: Added support for more truthy/falsy strings like "yes", "no", "y", "n" and ensured the parser doesn't crash on unrecognized input.
3. **CLI Ambiguity**: The tool previously misidentified the optional quantifier if the CSS selector was "ANY" or "EVERY". It now uses the total count of positional arguments to correctly identify when a quantifier is provided.
Comprehensive regression tests were added to ensure these fixes are correct and prevent future regressions.

---
*PR created automatically by Jules for task [1882203646338111574](https://jules.google.com/task/1882203646338111574) started by @agalazis*