### PR TITLE
Improve parsing logic and CLI argument handling

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,26 @@
+import sys
+from unittest.mock import patch
+from web_valueist.__main__ import _detect_optional_arguments
+
+def test_detect_optional_arguments_with_6_args():
+    test_args = ["web_valueist", "http://example.com", "int", "ANY", ".price", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is True
+
+def test_detect_optional_arguments_with_5_args_and_any_selector():
+    # If there are only 5 positional args, the 3rd one (index 2) is the selector.
+    # It should NOT be detected as a quantifier even if its value is "ANY".
+    test_args = ["web_valueist", "http://example.com", "int", "ANY", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is False
+
+def test_detect_optional_arguments_with_every_quantifier():
+    test_args = ["web_valueist", "http://example.com", "int", "EVERY", ".price", ">", "100"]
+    with patch.object(sys, 'argv', test_args):
+        config = {"quantifier": {"position": 2, "possible_values": ["ANY", "EVERY"]}}
+        result = _detect_optional_arguments(config)
+        assert result["quantifier"] is True

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -4,6 +4,9 @@ def test_clean_float_string():
     assert _clean_float_string("1,234.56") == "1234.56"
     assert _clean_float_string("1.234,56") == "1234.56"
     assert _clean_float_string("$ 10.50") == "10.50"
+    assert _clean_float_string("-10.50") == "-10.50"
+    assert _clean_float_string("-$ 10.50") == "-10.50"
+
 
 def test_parse_int():
     assert _parse_int("100") == 100
@@ -19,6 +22,11 @@ def test_parse_bool():
     assert _parse_bool("False") is False
     assert _parse_bool("1") is True
     assert _parse_bool("0") is False
+    assert _parse_bool("yes") is True
+    assert _parse_bool("no") is False
+    assert _parse_bool("y") is True
+    assert _parse_bool("n") is False
+
 
 def test_parse_interface():
     assert parse("int", "10") == 10

--- a/web_valueist/__main__.py
+++ b/web_valueist/__main__.py
@@ -23,13 +23,18 @@ class CliArgs(Args):
 
 def _detect_optional_arguments(config: dict[str, dict]):
     import sys
+
     positional_args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
     results = {}
     for name, attr in config.items():
         pos = attr["position"]
         possible_values = attr["possible_values"]
+        # Quantifier is at position 2 if there are 6 positional arguments.
+        # If there are only 5, then it's not present.
         results[name] = (
-            len(positional_args) > pos and positional_args[pos].upper() in possible_values
+            len(positional_args) == 6
+            and len(positional_args) > pos
+            and positional_args[pos].upper() in possible_values
         )
     return results
 

--- a/web_valueist/lib/parser.py
+++ b/web_valueist/lib/parser.py
@@ -8,10 +8,10 @@ type Parser = Literal["int", "str", "bool", "float"]
 
 INT_EXPONENT=Decimal('0')
 
-def _clean_float_string(val:str):
+def _clean_float_string(val: str):
     """Cleans up float string and returns float
     The cleanup regex does the following
-    1) Keeps only digits, commas and dots
+    1) Keeps only digits, commas, dots and leading minus sign
     2) Removes commas or dots that do not match coma or dot and the final 1 or 2 digits
 
 
@@ -19,9 +19,20 @@ def _clean_float_string(val:str):
         val (str): a string that is expected to be parsed as float
 
     Returns:
-        str: The float for the provided string 
-    """    
-    return re.sub(r"[^\d|\.|\,]|(?![.,]\d{1,2}$)[.,]", "", val).replace(',', '.')
+        str: The float for the provided string
+    """
+    # Keep only digits, commas, dots and leading minus
+    cleaned = re.sub(r"[^\d|.,-]", "", val)
+
+    # Ensure minus is only at the beginning
+    if cleaned.startswith("-"):
+        cleaned = "-" + cleaned[1:].replace("-", "")
+    else:
+        cleaned = cleaned.replace("-", "")
+
+    # Handle thousands separators and decimal points
+    # This regex removes dots or commas that are NOT followed by exactly 1 or 2 digits at the end of the string
+    return re.sub(r"(?![.,]\d{1,2}$)[.,]", "", cleaned).replace(",", ".")
 
 def _clean_bool_tiny_int_string(val: str):
     """Cleans up bool/tiny int values and returns tiny int string
@@ -32,7 +43,14 @@ def _clean_bool_tiny_int_string(val: str):
     Returns:
         str: The tiny int for the provided string 
     """
-    return re.sub('(?i)(?!true|false|1|0|t|f).', '',val).upper().replace('F','0').replace('T', '1')
+    return (
+        re.sub("(?i)(?!true|false|yes|no|1|0|t|f|y|n).", "", val)
+        .upper()
+        .replace("F", "0")
+        .replace("T", "1")
+        .replace("Y", "1")
+        .replace("N", "0")
+    )
 
 def _parse_int(val:str):
     """ Cleans up int string and returns int


### PR DESCRIPTION
This PR enhances the boolean and float parsing logic and improves the CLI's ability to disambiguate optional quantifier arguments from selectors. Boolean parsing now supports "yes/no/y/n" case-insensitively. Float parsing now correctly preserves leading negative signs. The CLI argument detection logic now checks the total number of positional arguments to correctly identify the optional quantifier, preventing misidentification when a selector is named "ANY" or "EVERY". New unit tests have been added to verify these improvements.

---
*PR created automatically by Jules for task [11895553142551099096](https://jules.google.com/task/11895553142551099096) started by @agalazis*