### PR TITLE
Add PyPI release GitHub Action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Build and publish Python distribution to PyPI
+    runs-on: ubuntu-latest
+
+    # Required for PyPI trusted publishing
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.8.3
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Build project for distribution
+      run: poetry build
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that automates publishing the project to PyPI whenever a new GitHub release is created. The workflow utilizes PyPI's trusted publishing (OIDC) mechanism for enhanced security, so no explicit credentials or tokens are needed in the repository settings.

Key points:
- The workflow triggers on `release: types: [published]`.
- It sets up Python 3.13 and installs Poetry to build the distribution package.
- It leverages the official `pypa/gh-action-pypi-publish` action.

---
*PR created automatically by Jules for task [8826674406936540095](https://jules.google.com/task/8826674406936540095) started by @agalazis*