### PR TITLE
ci: add environment to pypi-publish workflow to fix trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,6 +8,7 @@ jobs:
   pypi-publish:
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
 
     # Required for PyPI trusted publishing
     permissions:


### PR DESCRIPTION
Fixes the "Trusted publishing exchange failure" in the GitHub Actions PyPI publishing workflow.

The issue occurred because the OIDC token requested by the GitHub Actions job was missing the `environment` claim, resulting in an `invalid-publisher` error from PyPI: `valid token, but no corresponding publisher (Publisher with matching claims was not found)`.

This commit adds `environment: pypi` to the `pypi-publish` job, which ensures the `environment` claim is correctly populated in the OIDC token, allowing PyPI to validate the publisher against its configured environments.

---
*PR created automatically by Jules for task [12095705603945407524](https://jules.google.com/task/12095705603945407524) started by @agalazis*