### PR TITLE
ci: explicitly define environment for PyPI trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,7 +8,8 @@ jobs:
   pypi-publish:
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
 
     # Required for PyPI trusted publishing
     permissions:


### PR DESCRIPTION
Fixes the trusted publishing exchange failure where the `environment` claim was missing from the OIDC token. Explicitly defined the environment name in `.github/workflows/pypi-publish.yml` to satisfy PyPI's requirements.

---
*PR created automatically by Jules for task [12880383788016394759](https://jules.google.com/task/12880383788016394759) started by @agalazis*