### PR TITLE
Update documentation links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [![License](https://img.shields.io/github/license/agalazis/web-valueist.svg)](https://github.com/agalazis/web-valueist/blob/main/LICENSE)
 [![GitHub Issues](https://img.shields.io/github/issues/agalazis/web-valueist.svg)](https://github.com/agalazis/web-valueist/issues)
 [![CI](https://github.com/agalazis/web-valueist/actions/workflows/pypi-publish.yml/badge.svg)](https://github.com/agalazis/web-valueist/actions/workflows/pypi-publish.yml)
-[![Docs](https://github.com/agalazis/web-valueist/actions/workflows/docs-publish.yml/badge.svg)](http://web-valueist.csmonk.com/)
+[![Docs](https://github.com/agalazis/web-valueist/actions/workflows/docs-publish.yml/badge.svg)](https://web-valueist.csmonk.com/)
 
-[Documentation Website](http://web-valueist.csmonk.com/)
+[Documentation Website](https://web-valueist.csmonk.com/)
 
 Fetches a value from the web, compares it with a given value and exits with zero
 exit code if the condition is satisfied

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ beautifulsoup4 = "^4.12.3"
 requests = "^2.32.3"
 
 [tool.poetry.urls]
+"Documentation" = "https://web-valueist.csmonk.com/"
 "Issues" = "https://github.com/agalazis/web-valueist/issues"
 "Source Code" = "https://github.com/agalazis/web-valueist"
 "CI" = "https://github.com/agalazis/web-valueist/actions"


### PR DESCRIPTION
This PR updates the project's documentation links to use `https://` instead of `http://` as requested.
- Updated links in `README.md`
- Added the new documentation URL to the package URLs in `pyproject.toml` under `[tool.poetry.urls]` to ensure it is included in package releases.

---
*PR created automatically by Jules for task [3351796124607137659](https://jules.google.com/task/3351796124607137659) started by @agalazis*