### PR TITLE
fix: CI pipeline failures during poetry build and PyPI upload

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -32,6 +32,9 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
+    - name: Workaround for virtualenv 20.33.0 breaking poetry in github actions
+      run: poetry self add virtualenv==20.32.0
+
     - name: Build project for distribution
       run: poetry build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "web-valueist"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
-authors = ["Andreas Galazis"]
+authors = ["Andreas Galazis <agalazis@users.noreply.github.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This fixes the CI pipeline which failed during the latest release because:
1. The `authors` array in `pyproject.toml` lacked an email address, causing a validation failure when running `poetry build`.
2. A recent release of `virtualenv` (20.33.0) breaks `poetry` inside GitHub actions when installing isolated environments.
3. The previous failed workflow likely caused an incomplete upload or a metadata conflict on PyPI, returning a `400 Bad Request` during the upload phase.

The fixes applied are:
- Updating `authors` format in `pyproject.toml` to `Name <email>`.
- Updating `pypi-publish.yml` to downgrade `virtualenv` to 20.32.0 within Poetry's isolated environment using `poetry self add`.
- Bumping the `pyproject.toml` version to `1.0.1` to sidestep version collisions in PyPI.

---
*PR created automatically by Jules for task [4838129984291988148](https://jules.google.com/task/4838129984291988148) started by @agalazis*