### PR TITLE
ci: add prepare-release github action to automate version bumps

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,4 +75,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ env.NEW_VERSION }} --title "v${{ env.NEW_VERSION }}" --notes "Release v${{ env.NEW_VERSION }}"
+          NAVIGATORS=("Vasco da Gama" "Christopher Columbus" "Ferdinand Magellan" "James Cook" "Amerigo Vespucci" "Leif Erikson" "Ibn Battuta" "Zheng He" "Gerardus Mercator" "Ptolemy" "Abel Tasman" "John Cabot" "Bartolomeu Dias" "Jacques Cartier" "Hernán Cortés" "Roald Amundsen")
+
+          # Fetch previous release titles to find used names
+          USED_NAMES=$(gh release list --limit 100 | awk -F'\t' '{print $1}')
+
+          REMAINING=()
+          for nav in "${NAVIGATORS[@]}"; do
+            if ! echo "$USED_NAMES" | grep -q "$nav"; then
+              REMAINING+=("$nav")
+            fi
+          done
+
+          # If all names are used, reset and use the full list
+          if [ ${#REMAINING[@]} -eq 0 ]; then
+            REMAINING=("${NAVIGATORS[@]}")
+          fi
+
+          SELECTED_NAME=${REMAINING[$RANDOM % ${#REMAINING[@]}]}
+          gh release create v${{ env.NEW_VERSION }} --title "v${{ env.NEW_VERSION }} - $SELECTED_NAME" --notes "Release v${{ env.NEW_VERSION }} named after the famous historical navigator/cartographer: $SELECTED_NAME."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -93,4 +93,17 @@ jobs:
           fi
 
           SELECTED_NAME=${REMAINING[$RANDOM % ${#REMAINING[@]}]}
-          gh release create v${{ env.NEW_VERSION }} --title "v${{ env.NEW_VERSION }} - $SELECTED_NAME" --notes "Release v${{ env.NEW_VERSION }} named after the famous historical navigator/cartographer: $SELECTED_NAME."
+
+          # Extract the specific changelog section for this version
+          awk -v ver="${{ env.NEW_VERSION }}" '
+            /^## \[/ {
+              if (match($0, "^## \\[" ver "\\]")) { p=1; next }
+              else if (p) { p=0; nextfile }
+            }
+            p { print }
+          ' CHANGELOG.md > release_notes.md
+
+          # Prepend the intro message to the release notes
+          echo "Release v${{ env.NEW_VERSION }} named after the famous historical navigator/cartographer: **$SELECTED_NAME**." | cat - release_notes.md > temp_notes.md && mv temp_notes.md release_notes.md
+
+          gh release create v${{ env.NEW_VERSION }} --title "v${{ env.NEW_VERSION }} - $SELECTED_NAME" -F release_notes.md

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NAVIGATORS=("Vasco da Gama" "Christopher Columbus" "Ferdinand Magellan" "James Cook" "Amerigo Vespucci" "Leif Erikson" "Ibn Battuta" "Zheng He" "Gerardus Mercator" "Ptolemy" "Abel Tasman" "John Cabot" "Bartolomeu Dias" "Jacques Cartier" "Hernán Cortés" "Roald Amundsen")
+          mapfile -t NAVIGATORS < RELEASE_CANDIDATES
 
           # Fetch previous release titles to find used names
           USED_NAMES=$(gh release list --limit 100 | awk -F'\t' '{print $1}')

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,78 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type (patch, minor, major)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.3
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump_version
+        run: |
+          poetry version ${{ github.event.inputs.bump }}
+          NEW_VERSION=$(poetry version -s)
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Changelog
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          awk -v ver="${{ env.NEW_VERSION }}" -v date="$DATE" '
+            /^## \[.*\] - .*/ && !inserted {
+              print "## [" ver "] - " date
+              print ""
+              print "### Added"
+              print "- "
+              print ""
+              print $0
+              inserted = 1
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+
+      - name: Commit and Push
+        run: |
+          git add pyproject.toml CHANGELOG.md
+          git commit -m "chore: bump version to ${{ env.NEW_VERSION }}"
+          git push
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ env.NEW_VERSION }} --title "v${{ env.NEW_VERSION }}" --notes "Release v${{ env.NEW_VERSION }}"

--- a/RELEASE_CANDIDATES
+++ b/RELEASE_CANDIDATES
@@ -1,0 +1,59 @@
+Vasco da Gama
+Christopher Columbus
+Ferdinand Magellan
+James Cook
+Amerigo Vespucci
+Leif Erikson
+Ibn Battuta
+Zheng He
+Gerardus Mercator
+Ptolemy
+Abel Tasman
+John Cabot
+Bartolomeu Dias
+Jacques Cartier
+Hernán Cortés
+Roald Amundsen
+Willem Barentsz
+Pedro Álvares Cabral
+Henry Hudson
+Vitrus Bering
+Juan Sebastián Elcano
+Sir Francis Drake
+Martin Behaim
+Abraham Ortelius
+Joan Blaeu
+Al-Idrisi
+Giovanni da Verrazzano
+Fridtjof Nansen
+Pytheas
+Hanno the Navigator
+Samuel de Champlain
+Captain William Bligh
+William Baffin
+Alexander von Humboldt
+Sacagawea
+Matthew Flinders
+George Vancouver
+Jacques-Yves Cousteau
+Thor Heyerdahl
+Marco Polo
+Fernão Mendes Pinto
+Richard Francis Burton
+John Speke
+David Livingstone
+Henry Morton Stanley
+Mary Kingsley
+Gertrude Bell
+Ibn Khaldun
+Al-Masudi
+Xu Xiake
+Kupe
+Hui Te Rangiora
+Tupaia
+Nain Singh Rawat
+Kisaragi
+Ernest Shackleton
+Robert Falcon Scott
+Charles Wilkes
+Fabian Gottlieb von Bellingshausen

--- a/RELEASE_CANDIDATES
+++ b/RELEASE_CANDIDATES
@@ -1,12 +1,10 @@
 Vasco da Gama
 Christopher Columbus
-Ferdinand Magellan
 James Cook
 Amerigo Vespucci
 Leif Erikson
 Ibn Battuta
 Zheng He
-Gerardus Mercator
 Ptolemy
 Abel Tasman
 John Cabot

--- a/RELEASE_WORKFLOW.md
+++ b/RELEASE_WORKFLOW.md
@@ -1,0 +1,30 @@
+# Release Workflow
+
+This project uses an automated GitHub Actions workflow to handle new releases. The **Prepare Release** workflow manages versioning, changelog updates, and the creation of GitHub releases.
+
+## How to Trigger a Release
+
+You can trigger a new release manually from the GitHub website by following these steps:
+
+1. Go to the **Actions** tab in the repository.
+2. In the left sidebar, click on **Prepare Release**.
+3. On the right side, click the **Run workflow** dropdown button.
+4. Select the branch you want to run the workflow on (usually `main`).
+5. Choose the **Version bump type**:
+   - `patch`: Use for backward-compatible bug fixes (e.g., `1.0.0` -> `1.0.1`).
+   - `minor`: Use for new backward-compatible features (e.g., `1.0.0` -> `1.1.0`).
+   - `major`: Use for incompatible API changes (e.g., `1.0.0` -> `2.0.0`).
+6. Click the green **Run workflow** button.
+
+## What the Workflow Does Behind the Scenes
+
+Once triggered, the workflow automatically performs the following steps:
+
+1. **Checks out the repository.**
+2. **Sets up Python and installs Poetry.**
+3. **Bumps the version** in `pyproject.toml` using `poetry version <bump_type>`.
+4. **Updates `CHANGELOG.md`** by automatically adding a new release header (e.g., `## [1.0.1] - 2026-03-21`) and an `### Added` section at the top of the unreleased changes.
+5. **Commits and pushes** the updated `pyproject.toml` and `CHANGELOG.md` to the branch.
+6. **Creates a GitHub Release** using the GitHub CLI (`gh release create`), which automatically tags the new version in Git (e.g., `v1.0.1`).
+
+By creating a GitHub Release, this workflow subsequently triggers the existing `Publish to PyPI` and `Deploy docs to GitHub Pages` workflows, completing the full release pipeline.


### PR DESCRIPTION
Adds a new GitHub action workflow `prepare-release.yml` that can be triggered manually via workflow_dispatch with a chosen version bump type (patch, minor, major). It bumps the version in pyproject.toml using poetry, updates the CHANGELOG.md with a new release section, commits the changes, and creates a GitHub Release, which will then trigger the existing publish actions.

---
*PR created automatically by Jules for task [4470640798452619109](https://jules.google.com/task/4470640798452619109) started by @agalazis*