### PR TITLE
Uniform API: return value as list and introduce typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ python -m web_valueist http://example.com str h1 "eq" "Example Domain" --json
 
 Output:
 ```json
-{"args": {"url": "http://example.com", "parser_name": "str", "quantifier": "ANY", "selector": "h1", "operator_name": "eq", "value": "Example Domain"}, "result": {"success": true, "value": "Example Domain"}}
+{"args": {"url": "http://example.com", "parser_name": "str", "quantifier": "ANY", "selector": "h1", "operator_name": "eq", "value": "Example Domain"}, "result": {"success": true, "value": ["Example Domain"]}}
 ```
 
 #### Using Quantifiers

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -61,7 +61,7 @@ def test_evaluate_returns_dictionary_with_success_and_value(requests_mock):
 
     assert isinstance(result, dict)
     assert result["success"] is True
-    assert result["value"] == "100"
+    assert result["value"] == ["100"]
 
 def test_evaluate_with_float_parser(requests_mock):
     url = "https://example.com"
@@ -69,7 +69,7 @@ def test_evaluate_with_float_parser(requests_mock):
 
     result = evaluate(url, ".price", "float", ">", "100.25")
     assert result["success"] is True
-    assert result["value"] == "100.50"
+    assert result["value"] == ["100.50"]
 
 def test_evaluate_with_not_equal_operators(requests_mock):
     url = "https://example.com"

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -5,8 +5,13 @@ from .exception import ValueistException, ValueNotFound
 from .parser import Parser, ParserNotSupportedError
 from .operator import Operator, OperatorNotSupportedError
 import logging
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)
+
+class EvaluateResult(TypedDict):
+    success: bool
+    value: list[str]
 
 def _fetch_values(url: str, selector: str):
     response = requests.get(url, timeout=10)
@@ -40,7 +45,7 @@ def evaluate(
     operator_name: Operator,
     value: str,
     quantifier: str = "ANY",
-):
+) -> EvaluateResult:
 
     current_values = _fetch_values(url, selector)
     if logger.isEnabledFor(logging.DEBUG):
@@ -61,12 +66,13 @@ def evaluate(
 
     return {
         "success": success,
-        "value": current_values if len(current_values) > 1 else current_values[0],
+        "value": current_values,
     }
 
 
 __all__ = [
     "evaluate",
+    "EvaluateResult",
     "Parser",
     "Operator",
     "ParserNotSupportedError",


### PR DESCRIPTION
Updates the `evaluate` function in `web_valueist/lib/__init__.py` to always return a list for the `value` key, ensuring a consistent API. Also introduces the `EvaluateResult` TypedDict for better concrete typings. The README and test files have been modified to match the new list format.

---
*PR created automatically by Jules for task [7638198802416355164](https://jules.google.com/task/7638198802416355164) started by @agalazis*