### PR TITLE
feat: add strict_parsing mode and type hinted parsed returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ result = web_valueist.evaluate(
 )
 
 if result["success"]:
-    print(f"Match found! Fetched values (typed): {result['value']}")
+    print(f"Match found! Fetched values (typed): {result['values']}")
 else:
     print("Condition not met.")
 ```
@@ -145,7 +145,7 @@ python -m web_valueist http://example.com str h1 "eq" "Example Domain" --json
 
 Output:
 ```json
-{"args": {"url": "http://example.com", "parser_name": "str", "quantifier": "ANY", "selector": "h1", "operator_name": "eq", "value": "Example Domain"}, "result": {"success": true, "value": ["Example Domain"]}}
+{"args": {"url": "http://example.com", "parser_name": "str", "quantifier": "ANY", "selector": "h1", "operator_name": "eq", "value": "Example Domain"}, "result": {"success": true, "values": ["Example Domain"]}}
 ```
 
 #### Using Quantifiers

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pipenv install web-valueist
 
 ### Library
 
-You can import and use `web_valueist` directly in your Python code without relying on the CLI. The `evaluate` function returns a dictionary indicating whether the condition was met, along with the parsed values.
+You can import and use `web_valueist` directly in your Python code without relying on the CLI. The `evaluate` function returns a generic `EvaluateResult` dictionary indicating whether the condition was met, along with the extracted and typed parsed values (`list[int | float | str | bool]`). By default, if a value fails to parse it is silently filtered out, but you can enable `strict_parsing=True` to instead raise a `ParserError`.
 
 ```python
 import web_valueist
@@ -67,18 +67,19 @@ result = web_valueist.evaluate(
     parser_name="str",
     operator_name="eq",
     value="Example Domain",
-    quantifier="ANY" # Optional, defaults to "ANY"
+    quantifier="ANY", # Optional, defaults to "ANY"
+    strict_parsing=False # Optional, defaults to False. If True, unparsable values raise ParserError.
 )
 
 if result["success"]:
-    print(f"Match found! Fetched value: {result['value']}")
+    print(f"Match found! Fetched values (typed): {result['value']}")
 else:
     print("Condition not met.")
 ```
 
 ### CLI
 
-`web_valueist [-h] [--debug] [--json] url parser_name [quantifier] selector operator_name value`
+`web_valueist [-h] [--debug] [--json] [--strict-parsing] url parser_name [quantifier] selector operator_name value`
 
 ```text
 positional arguments:
@@ -90,9 +91,10 @@ positional arguments:
   value
 
 options:
-  -h, --help      show this help message and exit
-  --debug         Show debug logs including found values
-  --json          Output input and result as JSON
+  -h, --help         show this help message and exit
+  --debug            Show debug logs including found values
+  --json             Output input and result as JSON
+  --strict-parsing   Raise error if a fetched value cannot be parsed instead of filtering it
 ```
 
 #### Sample Usage

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -15,7 +15,7 @@ def test_evaluate_any_quantifier_returns_true_if_at_least_one_match_satisfies_co
     # ANY > 150 should be true because 200 > 150
     result = evaluate(url, ".price", "int", ">", "150", quantifier="ANY")
     assert result["success"] is True
-    assert result["value"] == [100, 200]
+    assert result["values"] == [100, 200]
 
 def test_evaluate_every_quantifier_returns_false_if_any_match_fails_condition(requests_mock):
     url = "https://example.com"
@@ -63,7 +63,7 @@ def test_evaluate_returns_dictionary_with_success_and_value(requests_mock):
 
     assert isinstance(result, dict)
     assert result["success"] is True
-    assert result["value"] == [100]
+    assert result["values"] == [100]
 
 def test_evaluate_with_float_parser(requests_mock):
     url = "https://example.com"
@@ -71,7 +71,7 @@ def test_evaluate_with_float_parser(requests_mock):
 
     result = evaluate(url, ".price", "float", ">", "100.25")
     assert result["success"] is True
-    assert result["value"] == [100.50]
+    assert result["values"] == [100.50]
 
 def test_evaluate_with_not_equal_operators(requests_mock):
     url = "https://example.com"
@@ -109,4 +109,4 @@ def test_evaluate_filters_unparsable_values_when_strict_parsing_false(requests_m
 
     result = evaluate(url, ".price", "int", ">", "50", strict_parsing=False)
     assert result["success"] is True
-    assert result["value"] == [100]
+    assert result["values"] == [100]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,8 @@
 import pytest
 from web_valueist import evaluate, ValueNotFound
 
+from web_valueist.lib.exception import ParserError
+
 def test_evaluate_any_quantifier_returns_true_if_at_least_one_match_satisfies_condition(requests_mock):
     url = "https://example.com"
     requests_mock.get(url, text='''
@@ -13,7 +15,7 @@ def test_evaluate_any_quantifier_returns_true_if_at_least_one_match_satisfies_co
     # ANY > 150 should be true because 200 > 150
     result = evaluate(url, ".price", "int", ">", "150", quantifier="ANY")
     assert result["success"] is True
-    assert result["value"] == ["100", "200"]
+    assert result["value"] == [100, 200]
 
 def test_evaluate_every_quantifier_returns_false_if_any_match_fails_condition(requests_mock):
     url = "https://example.com"
@@ -61,7 +63,7 @@ def test_evaluate_returns_dictionary_with_success_and_value(requests_mock):
 
     assert isinstance(result, dict)
     assert result["success"] is True
-    assert result["value"] == ["100"]
+    assert result["value"] == [100]
 
 def test_evaluate_with_float_parser(requests_mock):
     url = "https://example.com"
@@ -69,7 +71,7 @@ def test_evaluate_with_float_parser(requests_mock):
 
     result = evaluate(url, ".price", "float", ">", "100.25")
     assert result["success"] is True
-    assert result["value"] == ["100.50"]
+    assert result["value"] == [100.50]
 
 def test_evaluate_with_not_equal_operators(requests_mock):
     url = "https://example.com"
@@ -87,3 +89,24 @@ def test_evaluate_raises_value_not_found_when_selector_matches_nothing(requests_
 
     with pytest.raises(ValueNotFound):
         evaluate(url, ".non-existent", "str", "eq", "val")
+
+def test_evaluate_strict_parsing_raises_parser_error(requests_mock):
+    url = "https://example.com"
+    requests_mock.get(url, text='<html><body><span class="price">abc</span></body></html>')
+
+    with pytest.raises(ParserError):
+        evaluate(url, ".price", "int", ">", "50", strict_parsing=True)
+
+def test_evaluate_filters_unparsable_values_when_strict_parsing_false(requests_mock):
+    url = "https://example.com"
+    requests_mock.get(url, text='''
+        <html><body>
+            <span class="price">abc</span>
+            <span class="price">100</span>
+            <span class="price">def</span>
+        </body></html>
+    ''')
+
+    result = evaluate(url, ".price", "int", ">", "50", strict_parsing=False)
+    assert result["success"] is True
+    assert result["value"] == [100]

--- a/web_valueist/__main__.py
+++ b/web_valueist/__main__.py
@@ -13,7 +13,7 @@ class Args(TypedDict):
     parser_name: web_valueist.Parser
     operator_name: web_valueist.Operator
     value: str
-    quantifier: str
+    quantifier: web_valueist.Quantifier
     strict_parsing: bool
 
 

--- a/web_valueist/__main__.py
+++ b/web_valueist/__main__.py
@@ -14,6 +14,7 @@ class Args(TypedDict):
     operator_name: web_valueist.Operator
     value: str
     quantifier: str
+    strict_parsing: bool
 
 
 class CliArgs(Args):
@@ -47,7 +48,7 @@ def _parse_args() -> CliArgs:
 
     parser = ArgumentParser(
         prog="web_valueist",
-        usage="web_valueist [-h] [--debug] [--json] url parser_name [quantifier] selector operator_name value",
+        usage="web_valueist [-h] [--debug] [--json] [--strict-parsing] url parser_name [quantifier] selector operator_name value",
         description="""Fetches  the value from the web, compares 
         it with a given value and exits with zero exit code 
         if the condition is satisfied """,
@@ -74,6 +75,9 @@ def _parse_args() -> CliArgs:
     _ = parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     _ = parser.add_argument(
         "--json", action="store_true", help="Output input and result as JSON"
+    )
+    _ = parser.add_argument(
+        "--strict-parsing", action="store_true", help="Raise error if a fetched value cannot be parsed"
     )
 
     args = parser.parse_args().__dict__

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+type Quantifier = Literal["ANY", "EVERY"]
+
 class EvaluateResult(TypedDict, Generic[T]):
     success: bool
     value: list[T]
@@ -40,27 +42,27 @@ def _apply_operator(
 
 @overload
 def evaluate(
-    url: str, selector: str, parser_name: Literal["int"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+    url: str, selector: str, parser_name: Literal["int"], operator_name: Operator, value: str, quantifier: Quantifier = "ANY", strict_parsing: bool = False
 ) -> EvaluateResult[int]: ...
 
 @overload
 def evaluate(
-    url: str, selector: str, parser_name: Literal["float"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+    url: str, selector: str, parser_name: Literal["float"], operator_name: Operator, value: str, quantifier: Quantifier = "ANY", strict_parsing: bool = False
 ) -> EvaluateResult[float]: ...
 
 @overload
 def evaluate(
-    url: str, selector: str, parser_name: Literal["str"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+    url: str, selector: str, parser_name: Literal["str"], operator_name: Operator, value: str, quantifier: Quantifier = "ANY", strict_parsing: bool = False
 ) -> EvaluateResult[str]: ...
 
 @overload
 def evaluate(
-    url: str, selector: str, parser_name: Literal["bool"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+    url: str, selector: str, parser_name: Literal["bool"], operator_name: Operator, value: str, quantifier: Quantifier = "ANY", strict_parsing: bool = False
 ) -> EvaluateResult[bool]: ...
 
 @overload
 def evaluate(
-    url: str, selector: str, parser_name: Parser, operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+    url: str, selector: str, parser_name: Parser, operator_name: Operator, value: str, quantifier: Quantifier = "ANY", strict_parsing: bool = False
 ) -> EvaluateResult[int | float | str | bool]: ...
 
 def evaluate(
@@ -69,7 +71,7 @@ def evaluate(
     parser_name: Parser,
     operator_name: Operator,
     value: str,
-    quantifier: str = "ANY",
+    quantifier: Quantifier = "ANY",
     strict_parsing: bool = False,
 ) -> EvaluateResult[int | float | str | bool]:
 
@@ -110,6 +112,7 @@ __all__ = [
     "EvaluateResult",
     "Parser",
     "Operator",
+    "Quantifier",
     "ParserNotSupportedError",
     "OperatorNotSupportedError",
     "ValueistException",

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -15,7 +15,7 @@ type Quantifier = Literal["ANY", "EVERY"]
 
 class EvaluateResult(TypedDict, Generic[T]):
     success: bool
-    value: list[T]
+    values: list[T]
 
 def _fetch_values(url: str, selector: str):
     response = requests.get(url, timeout=10)
@@ -103,7 +103,7 @@ def evaluate(
 
     return {
         "success": success,
-        "value": parsed_current_values,
+        "values": parsed_current_values,
     }
 
 

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -1,17 +1,19 @@
 import requests
 from bs4 import BeautifulSoup
 from . import parser, operator
-from .exception import ValueistException, ValueNotFound
+from .exception import ValueistException, ValueNotFound, ParserError
 from .parser import Parser, ParserNotSupportedError
 from .operator import Operator, OperatorNotSupportedError
 import logging
-from typing import TypedDict
+from typing import TypedDict, Generic, TypeVar, Literal, overload, Any
 
 logger = logging.getLogger(__name__)
 
-class EvaluateResult(TypedDict):
+T = TypeVar("T")
+
+class EvaluateResult(TypedDict, Generic[T]):
     success: bool
-    value: list[str]
+    value: list[T]
 
 def _fetch_values(url: str, selector: str):
     response = requests.get(url, timeout=10)
@@ -29,14 +31,37 @@ def _fetch_values(url: str, selector: str):
 
 
 def _apply_operator(
-    parser_name: Parser,
-    current_value: str,
+    parsed_current_value: operator.ParsedValue,
     operator_name: Operator,
     parsed_reference_value: operator.ParsedValue,
 ):
-    parsed_current_value = parser.parse(parser_name, current_value)
     return operator.apply(operator_name, parsed_current_value, parsed_reference_value)
 
+
+@overload
+def evaluate(
+    url: str, selector: str, parser_name: Literal["int"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+) -> EvaluateResult[int]: ...
+
+@overload
+def evaluate(
+    url: str, selector: str, parser_name: Literal["float"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+) -> EvaluateResult[float]: ...
+
+@overload
+def evaluate(
+    url: str, selector: str, parser_name: Literal["str"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+) -> EvaluateResult[str]: ...
+
+@overload
+def evaluate(
+    url: str, selector: str, parser_name: Literal["bool"], operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+) -> EvaluateResult[bool]: ...
+
+@overload
+def evaluate(
+    url: str, selector: str, parser_name: Parser, operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
+) -> EvaluateResult[Any]: ...
 
 def evaluate(
     url: str,
@@ -45,28 +70,38 @@ def evaluate(
     operator_name: Operator,
     value: str,
     quantifier: str = "ANY",
-) -> EvaluateResult:
+    strict_parsing: bool = False,
+) -> EvaluateResult[Any]:
 
     current_values = _fetch_values(url, selector)
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("Found value %s", current_values)
 
     parsed_reference_value = parser.parse(parser_name, value)
+
+    parsed_current_values = []
+    for val in current_values:
+        try:
+            parsed_current_values.append(parser.parse(parser_name, val))
+        except ParserError:
+            if strict_parsing:
+                raise
+
     results = [
-        _apply_operator(parser_name, val, operator_name, parsed_reference_value)
-        for val in current_values
+        _apply_operator(parsed_val, operator_name, parsed_reference_value)
+        for parsed_val in parsed_current_values
     ]
     if quantifier == "ANY":
-        success = any(results)
+        success = any(results) if results else False
     elif quantifier == "EVERY":
-        success = all(results)
+        success = all(results) if results else False
     else:
         # Fallback to ANY if quantifier is unknown, or we could raise an error
-        success = any(results)
+        success = any(results) if results else False
 
     return {
         "success": success,
-        "value": current_values,
+        "value": parsed_current_values,
     }
 
 

--- a/web_valueist/lib/__init__.py
+++ b/web_valueist/lib/__init__.py
@@ -5,7 +5,7 @@ from .exception import ValueistException, ValueNotFound, ParserError
 from .parser import Parser, ParserNotSupportedError
 from .operator import Operator, OperatorNotSupportedError
 import logging
-from typing import TypedDict, Generic, TypeVar, Literal, overload, Any
+from typing import TypedDict, Generic, TypeVar, Literal, overload
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ def evaluate(
 @overload
 def evaluate(
     url: str, selector: str, parser_name: Parser, operator_name: Operator, value: str, quantifier: str = "ANY", strict_parsing: bool = False
-) -> EvaluateResult[Any]: ...
+) -> EvaluateResult[int | float | str | bool]: ...
 
 def evaluate(
     url: str,
@@ -71,7 +71,7 @@ def evaluate(
     value: str,
     quantifier: str = "ANY",
     strict_parsing: bool = False,
-) -> EvaluateResult[Any]:
+) -> EvaluateResult[int | float | str | bool]:
 
     current_values = _fetch_values(url, selector)
     if logger.isEnabledFor(logging.DEBUG):

--- a/web_valueist/lib/exception.py
+++ b/web_valueist/lib/exception.py
@@ -5,3 +5,10 @@ class ValueistException(Exception):
 class ValueNotFound(ValueistException):
     def __init__(self, *args: object) -> None:
         super().__init__("Value not found")
+
+
+class ParserError(ValueistException):
+    def __init__(self, value: str, parser_name: str) -> None:
+        self.value = value
+        self.parser_name = parser_name
+        super().__init__(f"Could not parse '{value}' as '{parser_name}'")

--- a/web_valueist/lib/parser.py
+++ b/web_valueist/lib/parser.py
@@ -1,8 +1,9 @@
 from decimal import ROUND_HALF_UP, Decimal
 import re
 from typing import Literal
+import decimal
 
-from .exception import ValueistException
+from .exception import ValueistException, ParserError
 
 type Parser = Literal["int", "str", "bool", "float"]
 
@@ -64,11 +65,17 @@ def _parse_int(val:str):
     Returns:
         int: The rounded integer for the provided string 
     """
-    float_string=_clean_float_string(val)
-    return int(Decimal(float_string).quantize(exp=INT_EXPONENT, rounding=ROUND_HALF_UP))
+    try:
+        float_string=_clean_float_string(val)
+        return int(Decimal(float_string).quantize(exp=INT_EXPONENT, rounding=ROUND_HALF_UP))
+    except (ValueError, decimal.InvalidOperation) as e:
+        raise ParserError(val, "int") from e
 
 def _parse_float(val:str):
-    return float(_clean_float_string(val))
+    try:
+        return float(_clean_float_string(val))
+    except ValueError as e:
+        raise ParserError(val, "float") from e
 
 def _parse_bool(val:str):
     """Cleans up bool/tiny int string and returns bool
@@ -79,8 +86,11 @@ def _parse_bool(val:str):
     Returns:
         bool: The boolean for the provided string
     """    
-    tiny_int_string = _clean_bool_tiny_int_string(val)
-    return bool(int(tiny_int_string))
+    try:
+        tiny_int_string = _clean_bool_tiny_int_string(val)
+        return bool(int(tiny_int_string))
+    except ValueError as e:
+        raise ParserError(val, "bool") from e
 
 _parsers = {
     "int": _parse_int, 


### PR DESCRIPTION
Implemented strict parsing feature and improved return types.

- Added `--strict-parsing` flag to the CLI and `strict_parsing=False` param to `evaluate()`.
- Added new `ParserError` exception.
- Caught errors like `ValueError` in `web_valueist.lib.parser` functions and raised `ParserError`.
- Changed `EvaluateResult` to use generics and return parsed values rather than strings.
- Added `@overload` type signatures to `evaluate()` so modern tooling can infer the return type from the string literal `parser_name`.
- Updated tests to verify new typing, filtering logic, and error handling.

---
*PR created automatically by Jules for task [15091693291085423950](https://jules.google.com/task/15091693291085423950) started by @agalazis*