### PR TITLE
ci: update release workflow to trigger downstream, generate notes, and include name in changelog

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -48,15 +48,50 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Pick Release Name
+        id: pick_name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mapfile -t NAVIGATORS < RELEASE_CANDIDATES
+
+          # Fetch previous release titles to find used names
+          USED_NAMES=$(gh release list --limit 100 | awk -F'	' '{print $1}')
+
+          REMAINING=()
+          for nav in "${NAVIGATORS[@]}"; do
+            if ! echo "$USED_NAMES" | grep -q "$nav"; then
+              REMAINING+=("$nav")
+            fi
+          done
+
+          # If all names are used, reset and use the full list
+          if [ ${#REMAINING[@]} -eq 0 ]; then
+            REMAINING=("${NAVIGATORS[@]}")
+          fi
+
+          SELECTED_NAME=${REMAINING[$RANDOM % ${#REMAINING[@]}]}
+          echo "SELECTED_NAME=$SELECTED_NAME" >> $GITHUB_ENV
+          echo "selected_name=$SELECTED_NAME" >> $GITHUB_OUTPUT
+
+      - name: Generate Release Notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/releases/generate-notes -f tag_name=v${{ env.NEW_VERSION }} -f target_commitish=${{ github.ref_name }} -q .body > generated_notes.md
+
+
+
       - name: Update Changelog
         run: |
           DATE=$(date +'%Y-%m-%d')
-          awk -v ver="${{ env.NEW_VERSION }}" -v date="$DATE" '
+          awk -v ver="${{ env.NEW_VERSION }}" -v name="${{ env.SELECTED_NAME }}" -v date="$DATE" '
             /^## \[.*\] - .*/ && !inserted {
-              print "## [" ver "] - " date
+              print "## [" ver "] - " name " - " date
               print ""
-              print "### Added"
-              print "- "
+              while ((getline line < "generated_notes.md") > 0)
+                print line
+              close("generated_notes.md")
               print ""
               print $0
               inserted = 1
@@ -73,26 +108,9 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         run: |
-          mapfile -t NAVIGATORS < RELEASE_CANDIDATES
-
-          # Fetch previous release titles to find used names
-          USED_NAMES=$(gh release list --limit 100 | awk -F'\t' '{print $1}')
-
-          REMAINING=()
-          for nav in "${NAVIGATORS[@]}"; do
-            if ! echo "$USED_NAMES" | grep -q "$nav"; then
-              REMAINING+=("$nav")
-            fi
-          done
-
-          # If all names are used, reset and use the full list
-          if [ ${#REMAINING[@]} -eq 0 ]; then
-            REMAINING=("${NAVIGATORS[@]}")
-          fi
-
-          SELECTED_NAME=${REMAINING[$RANDOM % ${#REMAINING[@]}]}
+          SELECTED_NAME="${{ env.SELECTED_NAME }}"
 
           # Extract the specific changelog section for this version
           awk -v ver="${{ env.NEW_VERSION }}" '

--- a/RELEASE_WORKFLOW.md
+++ b/RELEASE_WORKFLOW.md
@@ -23,8 +23,11 @@ Once triggered, the workflow automatically performs the following steps:
 1. **Checks out the repository.**
 2. **Sets up Python and installs Poetry.**
 3. **Bumps the version** in `pyproject.toml` using `poetry version <bump_type>`.
-4. **Updates `CHANGELOG.md`** by automatically adding a new release header (e.g., `## [1.0.1] - 2026-03-21`) and an `### Added` section at the top of the unreleased changes.
-5. **Commits and pushes** the updated `pyproject.toml` and `CHANGELOG.md` to the branch.
-6. **Creates a GitHub Release** using the GitHub CLI (`gh release create`), which automatically tags the new version in Git (e.g., `v1.0.1`).
+4. **Generates Release Notes** by using the GitHub API to fetch auto-generated release notes since the previous tag.
+5. **Updates `CHANGELOG.md`** by automatically adding a new release header (e.g., `## [1.0.1] - Columbus - 2026-03-21`) and injecting the generated release notes.
+6. **Commits and pushes** the updated `pyproject.toml` and `CHANGELOG.md` to the branch.
+7. **Creates a GitHub Release** using the GitHub CLI (`gh release create`), which automatically tags the new version in Git (e.g., `v1.0.1`).
 
 By creating a GitHub Release, this workflow subsequently triggers the existing `Publish to PyPI` and `Deploy docs to GitHub Pages` workflows, completing the full release pipeline.
+
+> **Note:** For the downstream workflows to be triggered successfully upon a GitHub Release, a repository secret named `PAT` (Personal Access Token) with the appropriate permissions must be provided. Actions performed with the default `GITHUB_TOKEN` intentionally prevent downstream workflow triggers to avoid infinite loops.


### PR DESCRIPTION
This updates `.github/workflows/prepare-release.yml` to:
- Move release name generation to its own step before creating the release.
- Introduce `gh api repos/${{ github.repository }}/releases/generate-notes` to automatically generate release notes for the new version.
- Use a `PAT` (Personal Access Token) for GitHub release creation, enabling downstream workflows (e.g. `Publish to PyPI` and `Deploy docs to GitHub Pages`) to run automatically.
- Inject the selected release name (from `RELEASE_CANDIDATES`) directly into the changelog header format, and paste the generated release notes into the changelog body.

Also updates `RELEASE_WORKFLOW.md` to document the new changelog format, auto-generated notes, and the requirement for a `PAT`.

---
*PR created automatically by Jules for task [14249148776170738432](https://jules.google.com/task/14249148776170738432) started by @agalazis*