### PR TITLE
🧹 Replace unused wildcard import in `web_valueist/__init__.py`

### DIFF
--- a/web_valueist/__init__.py
+++ b/web_valueist/__init__.py
@@ -1,4 +1,13 @@
-from .lib import *
+from .lib import (
+    evaluate,
+    Parser,
+    Operator,
+    Quantifier,
+    ParserNotSupportedError,
+    OperatorNotSupportedError,
+    ValueistException,
+    ValueNotFound,
+)
 
 __all__ = [
     "evaluate",


### PR DESCRIPTION
🎯 **What:** This change replaces the wildcard import (`from .lib import *`) in `web_valueist/__init__.py` with explicit imports for all items currently exported via `__all__`, plus the `Quantifier` type used internally by the CLI.

💡 **Why:** Wildcard imports are generally discouraged as they hide which names are added to the namespace, making the code harder to read and more prone to name clashes. Explicit imports improve maintainability and enable better static analysis by IDEs and linters.

✅ **Verification:** 
- Verified that the package and its CLI (`web_valueist.__main__`) can still be imported without `AttributeError` (specifically ensuring `Quantifier` is available).
- Ran all relevant unit tests (`tests/unit/test_parser.py`, `tests/unit/test_operator.py`, `tests/unit/test_cli.py`) in a restricted environment using temporary mocks for `requests` and `beautifulsoup4`.
- Confirmed that the `__all__` list remains unchanged, preserving the existing public API.

✨ **Result:** Improved code clarity and maintainability in the package's entry point without changing its public interface or behavior.

---
*PR created automatically by Jules for task [4119105003043214474](https://jules.google.com/task/4119105003043214474) started by @agalazis*