### PR TITLE
🧪 Add test for unknown quantifier fallback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock dependencies that might be missing in the environment
+# These must be mocked before any web_valueist module is imported.
+if 'requests' not in sys.modules:
+    sys.modules['requests'] = MagicMock()
+if 'bs4' not in sys.modules:
+    sys.modules['bs4'] = MagicMock()

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -1,14 +1,3 @@
-import sys
-from unittest.mock import MagicMock
-
-# Mock dependencies that might be missing in the environment
-# Use a local mock to avoid polluting the global namespace unnecessarily
-# although for these simple exception tests, we just need the module to be importable.
-if 'requests' not in sys.modules:
-    sys.modules['requests'] = MagicMock()
-if 'bs4' not in sys.modules:
-    sys.modules['bs4'] = MagicMock()
-
 from web_valueist.lib.exception import ValueistException, ValueNotFound, ParserError
 
 def test_valueist_exception():

--- a/tests/unit/test_quantifier_fallback.py
+++ b/tests/unit/test_quantifier_fallback.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+import web_valueist
+
+def test_evaluate_unknown_quantifier_falls_back_to_any():
+    """
+    Test that an unknown quantifier string results in 'ANY' behavior.
+    """
+    # Mock _fetch_values to avoid real network/parsing calls
+    # We patch it where it is used or defined. In this case, it's used in evaluate
+    # which is in web_valueist.lib.
+    with patch('web_valueist.lib._fetch_values') as mock_fetch:
+        mock_fetch.return_value = ["100", "200"]
+
+        # Case: "UNKNOWN" quantifier should act like "ANY"
+        # 200 > 150 is true, so ANY > 150 is true.
+        result = web_valueist.evaluate(
+            url="http://example.com",
+            selector=".price",
+            parser_name="int",
+            operator_name=">",
+            value="150",
+            quantifier="UNKNOWN" # type: ignore
+        )
+
+        assert result["success"] is True
+        assert result["values"] == [100, 200]
+
+        # Case: All fail
+        result = web_valueist.evaluate(
+            url="http://example.com",
+            selector=".price",
+            parser_name="int",
+            operator_name=">",
+            value="250",
+            quantifier="UNKNOWN" # type: ignore
+        )
+        assert result["success"] is False


### PR DESCRIPTION
This change addresses a testing gap where the fallback behavior for unknown quantifiers in the `evaluate` function was not explicitly tested. 

Key improvements:
- 🎯 **What:** Added a unit test for the edge case where an invalid quantifier string is passed to `evaluate`.
- 📊 **Coverage:** The new test covers scenarios where the fallback to "ANY" results in both success (at least one match) and failure (no matches satisfy the condition).
- ✨ **Result:** Increased test coverage and improved test maintainability by centralizing environment-specific dependency mocking in `tests/conftest.py`.

---
*PR created automatically by Jules for task [4684479239196463203](https://jules.google.com/task/4684479239196463203) started by @agalazis*