### PR TITLE
🧹 fix unused args and add formatted message support to exceptions

### DIFF
--- a/web_valueist/lib/exception.py
+++ b/web_valueist/lib/exception.py
@@ -3,8 +3,11 @@ class ValueistException(Exception):
 
 
 class ValueNotFound(ValueistException):
-    def __init__(self, *args: object) -> None:
-        super().__init__("Value not found")
+    def __init__(self, message: str | None = None) -> None:
+        base_message = "Value not found"
+        if message:
+            base_message = f"{base_message}: ({message})"
+        super().__init__(base_message)
 
 
 class ParserError(ValueistException):

--- a/web_valueist/lib/operator.py
+++ b/web_valueist/lib/operator.py
@@ -26,10 +26,11 @@ _operators = {
 
 
 class OperatorNotSupportedError(ValueistException):
-    def __init__(self, *args: object) -> None:
-        super().__init__(
-            f"Operator not supported. Possible operators are: {','.join(_operators.keys())}"
-        )
+    def __init__(self, message: str | None = None) -> None:
+        base_message = f"Operator not supported. Possible operators are: {','.join(_operators.keys())}"
+        if message:
+            base_message = f"{base_message}: ({message})"
+        super().__init__(base_message)
 
 
 def get_operator(operator_name: str):

--- a/web_valueist/lib/parser.py
+++ b/web_valueist/lib/parser.py
@@ -101,10 +101,11 @@ _parsers = {
 
 
 class ParserNotSupportedError(ValueistException):
-    def __init__(self, *args: object) -> None:
-        super().__init__(
-            f"Parser not supported. Possible parsers are: {','.join(_parsers.keys())}"
-        )
+    def __init__(self, message: str | None = None) -> None:
+        base_message = f"Parser not supported. Possible parsers are: {','.join(_parsers.keys())}"
+        if message:
+            base_message = f"{base_message}: ({message})"
+        super().__init__(base_message)
 
 
 def _get_parser(parser_name: str):


### PR DESCRIPTION
This PR improves code health by removing unused `*args` from exception constructors and adding support for an optional descriptive message.

Changes:
- Refactored `ParserNotSupportedError` (`web_valueist/lib/parser.py`), `OperatorNotSupportedError` (`web_valueist/lib/operator.py`), and `ValueNotFound` (`web_valueist/lib/exception.py`).
- Replaced the ignored `*args` with a named optional `message: str | None = None` parameter.
- The `__init__` methods now concatenate the provided `message` to the base error string using the format `f"{base_message}: ({message})"`.

Verification:
- Created a validation script `verify_format.py` that mocks dependencies and tests instantiation both with and without the optional message.
- Confirmed that the default error message is preserved when no custom message is provided.
- Confirmed that custom messages are correctly appended in the requested format.
- Verified that all unit tests still pass (using mocks for missing environment dependencies).

---
*PR created automatically by Jules for task [2315435399105451116](https://jules.google.com/task/2315435399105451116) started by @agalazis*