### PR TITLE
🧹 move local imports to top-level in __main__.py

### DIFF
--- a/web_valueist/__main__.py
+++ b/web_valueist/__main__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import json
 import logging
+import sys
 import web_valueist
 from argparse import ArgumentParser
 from typing import TypedDict, Unpack
@@ -23,8 +25,6 @@ class CliArgs(Args):
 
 
 def _detect_optional_arguments(config: dict[str, dict]):
-    import sys
-
     positional_args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
     results = {}
     for name, attr in config.items():
@@ -110,8 +110,6 @@ def sigterm_handler(_, __):
 
 
 def main():
-    import json
-    import sys
     args=_initialize_cli()
     json_output = args.pop("json")
     result = web_valueist.evaluate(**args)
@@ -129,10 +127,10 @@ def __main__():
         main()
     except KeyboardInterrupt:
         logger.error("ok, bye...\n")
-        exit(1)
+        sys.exit(1)
     except web_valueist.ValueistException as e:
         logger.error(f"Error: {e}")
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
This PR refactors `web_valueist/__main__.py` to move all local imports (specifically `sys` and `json`) to the top-level of the file. It also standardizes the use of `sys.exit()` over the built-in `exit()` in the CLI entry point.

💡 **Why:** How this improves maintainability
- **PEP 8 Compliance:** Python conventions suggest placing all imports at the top of the file for better visibility and performance (avoiding re-importing on every function call).
- **Readability:** Centralizing imports makes dependencies of the module clear at a glance.
- **Consistency:** Using `sys.exit()` is preferred for scripts and production code over `exit()`, which is primarily intended for interactive shells.

✅ **Verification:** How you confirmed the change is safe
- **Manual Verification:** Used `grep`, `head`, and `tail` to ensure imports were correctly relocated and local ones were removed.
- **Test Suite:** Ran `PYTHONPATH=. pytest`. All 19 unit tests passed successfully. Known integration test errors related to missing environment-specific dependencies (`requests_mock`) were confirmed to be unrelated to these changes.

✨ **Result:** The improvement achieved
The codebase now follows standard Python import conventions, improving linting compliance and long-term maintainability of the CLI component.

---
*PR created automatically by Jules for task [5491800764189590595](https://jules.google.com/task/5491800764189590595) started by @agalazis*