### PR TITLE
🧹 Remove unused `ParsedValue` type alias and `apply` function

### DIFF
--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,25 +1,25 @@
-from web_valueist.lib.operator import apply
+from web_valueist.lib.operator import get_operator
 
-def test_apply_comparison_operators():
-    assert apply("gt", 100, 50) is True
-    assert apply(">", 100, 50) is True
-    assert apply("lt", 50, 100) is True
-    assert apply("<", 50, 100) is True
-    assert apply("ge", 100, 100) is True
-    assert apply(">=", 100, 50) is True
-    assert apply("le", 50, 50) is True
-    assert apply("<=", 50, 100) is True
+def test_get_operator_comparison_operators():
+    assert get_operator("gt")(100, 50) is True
+    assert get_operator(">")(100, 50) is True
+    assert get_operator("lt")(50, 100) is True
+    assert get_operator("<")(50, 100) is True
+    assert get_operator("ge")(100, 100) is True
+    assert get_operator(">=")(100, 50) is True
+    assert get_operator("le")(50, 50) is True
+    assert get_operator("<=")(50, 100) is True
 
-def test_apply_equality_operators():
-    assert apply("eq", "apple", "apple") is True
-    assert apply("=", "apple", "apple") is True
-    assert apply("eq", 100, 100) is True
+def test_get_operator_equality_operators():
+    assert get_operator("eq")("apple", "apple") is True
+    assert get_operator("=")("apple", "apple") is True
+    assert get_operator("eq")(100, 100) is True
 
-    assert apply("ne", "apple", "orange") is True
-    assert apply("!=", "apple", "apple") is False
-    assert apply("ne", 100, 200) is True
+    assert get_operator("ne")("apple", "orange") is True
+    assert get_operator("!=")("apple", "apple") is False
+    assert get_operator("ne")(100, 200) is True
 
-def test_apply_with_mixed_types():
-    assert apply("gt", 100.5, 100.25) is True
-    assert apply("lt", 50.5, 100) is True
-    assert apply("eq", 100.0, 100) is True
+def test_get_operator_with_mixed_types():
+    assert get_operator("gt")(100.5, 100.25) is True
+    assert get_operator("lt")(50.5, 100) is True
+    assert get_operator("eq")(100.0, 100) is True

--- a/web_valueist/lib/operator.py
+++ b/web_valueist/lib/operator.py
@@ -7,8 +7,6 @@ type Operator = Literal[
     "gt", ">", "lt", "<", "ge", ">=", "le", "<=", "eq", "=", "ne", "!="
 ]
 
-type ParsedValue = str | int | float | bool
-
 _operators = {
     "gt": operator.gt,
     ">": operator.gt,
@@ -38,7 +36,3 @@ def get_operator(operator_name: str):
         return _operators[operator_name]
     except KeyError as exception:
         raise OperatorNotSupportedError from exception
-
-
-def apply(operator_name: Operator, a: ParsedValue, b: ParsedValue) -> bool:
-    return get_operator(operator_name)(a, b)


### PR DESCRIPTION
🎯 **What:** Removed `ParsedValue` type alias and the `apply` function from `web_valueist/lib/operator.py`.
💡 **Why:** `ParsedValue` wasn't being used elsewhere, and `apply` was a thin, redundant wrapper over `get_operator()(a, b)`. Removing them reduces duplication and improves code readability.
✅ **Verification:** Updated `tests/unit/test_operator.py` to invoke `get_operator` directly. Ran the full pytest suite (`poetry run pytest`), confirming that all 35 tests pass and no functionality is broken.
✨ **Result:** Cleaned up `operator.py` and updated its dependent tests appropriately without changing runtime behavior.

---
*PR created automatically by Jules for task [6290789149819498680](https://jules.google.com/task/6290789149819498680) started by @agalazis*