### PR TITLE
🧹 Remove unused `apply` function from operator.py

### DIFF
--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,25 +1,25 @@
-from web_valueist.lib.operator import apply
+from web_valueist.lib.operator import get_operator
 
 def test_apply_comparison_operators():
-    assert apply("gt", 100, 50) is True
-    assert apply(">", 100, 50) is True
-    assert apply("lt", 50, 100) is True
-    assert apply("<", 50, 100) is True
-    assert apply("ge", 100, 100) is True
-    assert apply(">=", 100, 50) is True
-    assert apply("le", 50, 50) is True
-    assert apply("<=", 50, 100) is True
+    assert get_operator("gt")(100, 50) is True
+    assert get_operator(">")(100, 50) is True
+    assert get_operator("lt")(50, 100) is True
+    assert get_operator("<")(50, 100) is True
+    assert get_operator("ge")(100, 100) is True
+    assert get_operator(">=")(100, 50) is True
+    assert get_operator("le")(50, 50) is True
+    assert get_operator("<=")(50, 100) is True
 
 def test_apply_equality_operators():
-    assert apply("eq", "apple", "apple") is True
-    assert apply("=", "apple", "apple") is True
-    assert apply("eq", 100, 100) is True
+    assert get_operator("eq")("apple", "apple") is True
+    assert get_operator("=")("apple", "apple") is True
+    assert get_operator("eq")(100, 100) is True
 
-    assert apply("ne", "apple", "orange") is True
-    assert apply("!=", "apple", "apple") is False
-    assert apply("ne", 100, 200) is True
+    assert get_operator("ne")("apple", "orange") is True
+    assert get_operator("!=")("apple", "apple") is False
+    assert get_operator("ne")(100, 200) is True
 
 def test_apply_with_mixed_types():
-    assert apply("gt", 100.5, 100.25) is True
-    assert apply("lt", 50.5, 100) is True
-    assert apply("eq", 100.0, 100) is True
+    assert get_operator("gt")(100.5, 100.25) is True
+    assert get_operator("lt")(50.5, 100) is True
+    assert get_operator("eq")(100.0, 100) is True

--- a/web_valueist/lib/operator.py
+++ b/web_valueist/lib/operator.py
@@ -38,7 +38,3 @@ def get_operator(operator_name: str):
         return _operators[operator_name]
     except KeyError as exception:
         raise OperatorNotSupportedError from exception
-
-
-def apply(operator_name: Operator, a: ParsedValue, b: ParsedValue) -> bool:
-    return get_operator(operator_name)(a, b)


### PR DESCRIPTION
🎯 **What:** Removed the unused `apply` function from `web_valueist/lib/operator.py` and updated unit tests to call `get_operator` directly.
💡 **Why:** The `apply` function was unnecessary abstraction and dead code in the main execution path since the project migrated to directly calling the operator functions retrieved via `get_operator()`. Removing it improves code maintainability and readability by eliminating a redundant layer.
✅ **Verification:** Ran the full pytest suite locally (`pytest tests/unit/test_operator.py` and others) to ensure the change introduces no regressions and all tests continue to pass correctly. Code review requested and cleared.
✨ **Result:** Cleaned up unused dead code, simplifying the codebase without affecting any core functionality.

---
*PR created automatically by Jules for task [15523097876607764157](https://jules.google.com/task/15523097876607764157) started by @agalazis*